### PR TITLE
Ignore the gradle.properties in order to change the title.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 !README.md
 !build.gradle.kts
 !settings.gradle.kts
-!gradle.properties


### PR DESCRIPTION
I name my repository groups by changing the title. I'll have Primary, Secondary, etc.

So far I have been setting "Assume unchanged" for the gradle.properties file, but perhaps this would be okay.

The main hesitation here would be that if someone messes with the other settings and gets stuck, a "reset" doesn't fix it for them.