### PR TITLE
Tools: Detect default branches and update submodules

### DIFF
--- a/.tools/common_git_functions.sh
+++ b/.tools/common_git_functions.sh
@@ -3,6 +3,14 @@ is_git_repo() {
   git -C "$1" rev-parse --is-inside-work-tree &>/dev/null
 }
 
+# Returns the remote default branch name (e.g. develop, main).
+get_default_branch() {
+  local repo_dir="${1:?repo dir required}" remote="${2:-origin}"
+  git -C "$repo_dir" symbolic-ref "refs/remotes/${remote}/HEAD" 2>/dev/null | sed 's|.*/||' \
+    || git -C "$repo_dir" ls-remote --symref "$remote" HEAD 2>/dev/null \
+    | awk '/^ref:/ { sub("refs/heads/", "", $2); print $2; exit }'
+}
+
 find_repo_dirs() {
   # 1. Recursively find .git folders.
   # 2. Remove the /.git from path.
@@ -14,14 +22,22 @@ find_repo_dirs() {
   | sort
 }
 
-# Recursively runs git commands on all git repos in a directory
+# Recursively runs git commands on all git repos in a directory.
+# Use _default_ in place of a branch name to use each repo's default branch.
 git_recursive() {
   mapfile -t repo_dirs < <(find_repo_dirs)
 
   for repo_dir in "${repo_dirs[@]}"; do
     if is_git_repo "$repo_dir"; then
-      echo "git -C \"$repo_dir\" $*"
-      git -C "$repo_dir" "$@"
+      local args=() arg
+      for arg in "$@"; do
+        if [ "$arg" = "_default_" ]; then
+          arg=$(get_default_branch "$repo_dir")
+        fi
+        args+=("$arg")
+      done
+      echo "git -C \"$repo_dir\" ${args[*]}"
+      git -C "$repo_dir" "${args[@]}"
     fi
   done
 }

--- a/.tools/git_recursive_reset_branch.sh
+++ b/.tools/git_recursive_reset_branch.sh
@@ -6,6 +6,7 @@ git_recursive fetch --all --prune
 git_recursive checkout _default_
 git_recursive reset --hard
 git_recursive pull
+git_recursive submodule update --init --recursive
 
 git_recursive_delete_merged_branches
 
@@ -13,5 +14,6 @@ if [ -n "$1" ]; then
   git_recursive checkout "$1"
   git_recursive reset --hard
   git_recursive pull
+  git_recursive submodule update --init --recursive
   git_recursive rebase _default_
 fi

--- a/.tools/git_recursive_reset_branch.sh
+++ b/.tools/git_recursive_reset_branch.sh
@@ -3,15 +3,15 @@
 source "$(dirname "$0")/common_git_functions.sh"
 
 git_recursive fetch --all --prune
-git_recursive checkout develop
+git_recursive checkout _default_
 git_recursive reset --hard
 git_recursive pull
 
 git_recursive_delete_merged_branches
 
-if [ "$1" != "develop" ]; then
+if [ -n "$1" ]; then
   git_recursive checkout "$1"
   git_recursive reset --hard
   git_recursive pull
-  git_recursive rebase develop
+  git_recursive rebase _default_
 fi

--- a/README.md
+++ b/README.md
@@ -27,18 +27,17 @@ repository-group $ .tools/git_recursive.sh [git args ...]
 # Delete local branches after the PR has been merged.
 repository-group $ .tools/git_recursive_delete_merged_branches.sh
 
-# Reset to a branch and rebase it with develop.
+# Reset all repos to each repo's default branch (develop, main, etc.), update submodules, and delete merged branches.
+# With a branch name: also check out that branch (if it exists) and rebase it onto each repo's default.
 # WARNING: Discard local changes first!
-# This checks out develop, pulls, fetches,
-# checks out, and rebases your branch onto develop.
-repository-group $ .tools/git_recursive_reset_branch.sh branch-name
+repository-group $ .tools/git_recursive_reset_branch.sh [branch-name]
 
 # Examples:
 
 # Fetch all repos 
 repository-group $ .tools/git_recursive.sh fetch --all
 
-# Start working on your feature and make sure you're up to date with develop
+# Start working on your feature and make sure you're up to date
 repository-group $ .tools/git_recursive_reset_branch.sh feature/improvements
 ```
 


### PR DESCRIPTION
Recursive git scripts now resolve each repo's default branch (`develop`, `main`, `master`, etc.) instead of hardcoding `develop`. Pass `_default_` to `git_recursive` to substitute the per-repo default in any git command.

`git_recursive_reset_branch.sh` uses this for checkout/rebase and also runs `git submodule update --init --recursive` after each pull.